### PR TITLE
revert `run` command to `php`

### DIFF
--- a/wasmer.toml
+++ b/wasmer.toml
@@ -10,7 +10,7 @@ entrypoint = "run"
 "/app" = "."
 
 [[command]]
-name = "run"
+name = "php"
 module = "php/php:php"
 runner = "wasi"
 [command.annotations.wasi]

--- a/wasmer.toml
+++ b/wasmer.toml
@@ -1,5 +1,5 @@
 [package]
-entrypoint = "run"
+entrypoint = "php"
 
 
 [dependencies]


### PR DESCRIPTION
this is because the backend expects `php` endpoint to set single-concurrency.