### PR TITLE
Switch back to SPAWN cronjob for the wp-cron

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -15,10 +15,29 @@ jobs:
   action:
     execute:
       command: install-wp
+# Invoke cron with fetch.
+# Currently disabled because it causes redundant instances to stay alive for
+# minutes.
+# - name: wp-cron
+#   trigger: '*/15 * * * *'
+#   action:
+#     fetch:
+#       path: /wp-cron.php
+#       timeout: '10m'
+# Invoke cron with a separate instance.
 - name: wp-cron
   trigger: '*/15 * * * *'
   action:
-    fetch:
-      path: /wp-cron.php
-      timeout: '10m'
+    execute:
+      package: "php/php-eh@=8.3.404-beta.4"
+      command: php
+      cli_args:
+      - /app/wp-cli/php/boot-fs.php
+      - cron
+      - event
+      - run
+      - '--due-now'
+      volumes:
+      - name: wp-content
+        mount: /app/wp-content
 kind: wasmer.io/App.v0


### PR DESCRIPTION
Done to ease the load on Edge by preventing instances to stay alive for too long.
